### PR TITLE
(#1) nginx class design leads to dependency cycles

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -23,10 +23,11 @@ define nginx::file (
   $source  = undef
 ) {
   include nginx::params
+
   file { "${nginx::params::confdir}/conf.d/${title}":
     content => $content,
     source  => $source,
-    notify  => Service['nginx'],
+    notify  => Class['nginx::service'],
     require => Class['nginx'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,19 +86,8 @@ class nginx (
   $mime_types = false
 ) inherits nginx::params {
 
-  package { $nginx::params::package:
-    alias  => 'nginx',
-    ensure => installed,
-  }
-
-  service { $nginx::params::service:
-    enable    => true,
-    ensure    => running,
-    restart   => $nginx::params::service_restart,
-    hasstatus => true,
-    require   => Package['nginx'],
-    alias     => 'nginx',
-  }
+  include nginx::install,
+          nginx::service
 
   # Main configuration file
   file { "${confdir}/nginx.conf":
@@ -106,8 +95,6 @@ class nginx (
     group   => 'root',
     mode    => '0644',
     content => template('nginx/nginx.conf.erb'),
-    notify  => Service['nginx'],
-    require => Package['nginx'],
   }
   # Directory for configuration snippets
   file { "${confdir}/conf.d":
@@ -115,7 +102,6 @@ class nginx (
     owner   => 'root',
     group   => 'root',
     mode    => '0755',
-    require => Package['nginx'],
   }
 
   # Default configuration file included in the package (usually unwanted)
@@ -125,7 +111,6 @@ class nginx (
       group   => 'root',
       mode    => '0644',
       content => "# Empty, not removed, to not reappear when the package is updated.\n",
-      require => Package['nginx'],
     }
   }
 
@@ -136,10 +121,9 @@ class nginx (
       group   => 'root',
       mode    => '0644',
       content => template('nginx/mime.types.erb'),
-      require => Package['nginx'],
-      notify  => Service['nginx'],
     }
   }
 
+  Class['nginx::install'] -> Class['nginx']
+  Class['nginx'] ~> Class['nginx::service']
 }
-

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,18 @@
+# Class: nginx::install
+#
+# Install the NGINX web server package.
+#
+# Parameters :
+#  none
+#
+# Sample Usage :
+#  include nginx::install
+#
+class nginx::install {
+  include nginx::params
+
+  package { $nginx::params::package:
+    alias  => 'nginx',
+    ensure => installed,
+  }
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,0 +1,21 @@
+# Class: nginx::service
+#
+# Enable the NGINX web server.
+#
+# Parameters :
+#  none
+#
+# Sample Usage :
+#  include nginx::service
+#
+class nginx::service {
+  include nginx::params
+
+  service { $nginx::params::service:
+    enable    => true,
+    ensure    => running,
+    restart   => $nginx::params::service_restart,
+    hasstatus => true,
+    alias     => 'nginx',
+  }
+}


### PR DESCRIPTION
This change splits the installation and service responsibilities from the
nginx class into nginx::install and nginx::service classes respectively. The
reason for this change is to prevent dependency cycles when defining files
that need to require the nginx class and notify the nginx service. Note that
this change does not change the existing interfaces, so it is backward
compatible.

Closes #1
