### PR TITLE
Allow Debian-ish systems to make use of this Puppet module

### DIFF
--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -108,8 +108,8 @@ proxy_buffer_size <%= @proxy_buffer_size %>;
     # Include separately managed configuration file(s)
     include /etc/nginx/conf.d/*.conf;
 
-    # Include enabled site(s)
 <% case @operatingsystem when 'Debian', 'Ubuntu' -%>
+    # Include enabled site(s)
     include /etc/nginx/sites-enabled/*;
 <% end -%>
 }


### PR DESCRIPTION
I don't know offhand how Redhat-ish systems handle the equivalent of /etc/nginx/sites-[available|enabled], but Debian-ish systems need to handle it.
