### PR TITLE
Notify nginx after we replace default.conf.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,6 +127,7 @@ class nginx (
       mode    => '0644',
       content => "# Empty, not removed, to not reappear when the package is updated.\n",
       require => Package['nginx'],
+      notify  => Service['nginx'],
     }
   }
 


### PR DESCRIPTION
When using this module, I experienced an issue that puppet would not reload nginx after replacing the default.conf.

This fix worked for me to address that.
