### PR TITLE
Swap out an "if" in the nginx configuration in favour of try_files

### DIFF
--- a/files/php.conf.inc
+++ b/files/php.conf.inc
@@ -2,7 +2,8 @@
 location ~ \.php$ {
     # Don't bother PHP if the file doesn't exist, return the built in
     # 404 page (this also avoids "No input file specified" error pages)
-    if (!-f $request_filename) { return 404; }
+    try_files     $uri =404;
+
     include       /etc/nginx/fastcgi.conf;
     fastcgi_pass  fpmbackend;
 }


### PR DESCRIPTION
Nginx's documentation suggests that one should favour `try_files` over an `if` wherever possible[1], as do some blogs[2]. So this commit changes that.

Test cases I tried with the modfied line:
- File exists (http://www.example.com/index.php)
- File doesn't exist (http://www.example.com/404-generator.php)
- Default file (http://www.example.com/)
- Non-PHP file (http://www.example.com/test.html)
- Security test to run a non-PHP file as PHP (http://www.example.com/test.html/test.php) [2]

[1] http://wiki.nginx.org/IfIsEvil
[2] http://mckelvaney.co.uk/blog/2013/04/30/deploying-lessn-more-with-nginx-and-try-files/
[3] https://nealpoole.com/blog/2011/04/setting-up-php-fastcgi-and-nginx-dont-trust-the-tutorials-check-your-configuration/
