### PR TITLE
Fixing http_raw_lines issue

### DIFF
--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -112,7 +112,7 @@ http {
 <% if !@http_raw_lines.empty? -%>
 
     # Other
-<% @http_raw_lines.empty.each do |line| -%>
+<% @http_raw_lines.each do |line| -%>
     <%= line %>;
 <% end -%>
 <% end -%>


### PR DESCRIPTION
The parameter http_raw_lines doesn't work currently due to an extraneous .empty in the .each line.
