### PR TITLE
Change worker_processes to match the number of CPU

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,7 +56,7 @@ class nginx (
   $env = [],
   # HTTP module options
   $user = $::nginx::params::user,
-  $worker_processes = 'auto',
+  $worker_processes = $::processorcount,
   $worker_cpu_affinity = undef,
   $worker_rlimit_nofile = false,
   $error_log = '/var/log/nginx/error.log',


### PR DESCRIPTION
having it set to 'auto'  caused Nginx not to start because of a syntax error in the config file. Using the $::processorcount fact is a good default.
