### PR TITLE
Add support for multiple error_log directives when passing error_log …

### DIFF
--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -9,7 +9,9 @@ worker_cpu_affinity <%= @worker_cpu_affinity %>;
 <% if @worker_rlimit_nofile -%>
 worker_rlimit_nofile <%= @worker_rlimit_nofile %>;
 <% end -%>
-error_log <%= @error_log %>;
+<%- @error_log.each do |logfile| -%>
+error_log <%= logfile %>;
+<%- end -%>
 pid /var/run/nginx.pid;
 
 events {


### PR DESCRIPTION
…parameter as array

Multiple error_log directives are supported by nginx since version 1.5.2 so why not support then in the module?. The change is backward compatible as ruby .each method works on both: an array and a string.